### PR TITLE
fix: console regex for function calls inside it

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 export async function removeConsolesFromDocument(document: vscode.TextDocument): Promise<void> {
-  const consoleDotLogRegex = /console\.log\s*\([\s\S]*?\)(?:\s*;)?/g
+  const consoleDotLogRegex = /console\.log\s*\([\s\S]*?\)(?:\s*;)?\s*\)?/g
   const currentDocText = document.getText()
 
   if (!consoleDotLogRegex.test(currentDocText)) {


### PR DESCRIPTION
- consoleDotLogRegex fixed for function calls inside console.log function
